### PR TITLE
Added support for eager rendering of children

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ takes the following props:
 * `className` allows a CSS class name to be added to the outer element. Care
  should be taken if any rules added by the class name conflict with
  SmoothCollapse's own CSS properties.
+ * `eagerRender` will ensure that all children are always rendered, even if they
+ have never been expanded. This property defaults to false.
 
-If the SmoothCollapse component starts out with expanded set to false and
-collapsedHeight is 0, then the children are not rendered until the first time
-the component is expanded. After the component has been expanded once, the
-children stay rendered so that they don't lose their state when they're hidden.
+If the SmoothCollapse component starts out with expanded set to false, eagerRender
+is set to false, and collapsedHeight is 0 , then the children are not rendered until
+the first time the component is expanded. After the component has been expanded
+once, the children stay rendered so that they don't lose their state when they're
+hidden.
 
 ## Types
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export type Props = {
   heightTransition: string;
   className: string;
   allowOverflowWhenOpen: boolean;
+  eagerRender: boolean;
 };
 type State = {
   hasBeenVisibleBefore: boolean;
@@ -37,13 +38,15 @@ export default class SmoothCollapse extends React.Component<Props,State> {
     collapsedHeight: PropTypes.string,
     heightTransition: PropTypes.string,
     className: PropTypes.string,
-    allowOverflowWhenOpen: PropTypes.bool
+    allowOverflowWhenOpen: PropTypes.bool,
+    eagerRender: PropTypes.bool
   };
   static defaultProps = {
     collapsedHeight: '0',
     heightTransition: '.25s ease',
     className: '',
     allowOverflowWhenOpen: false,
+    eagerRender: false
   };
 
   constructor(props: Props) {
@@ -57,7 +60,7 @@ export default class SmoothCollapse extends React.Component<Props,State> {
 
   _visibleWhenClosed(props: ?Props) {
     if (!props) props = this.props;
-    return parseFloat(props.collapsedHeight) !== 0;
+    return props.eagerRender || parseFloat(props.collapsedHeight) !== 0;
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Added support for eager rendering of children, even if they have never been expanded.  

A specific case where this is needed is if the collapsed content is wrapped in a component that defers rendering, such as `react-container-dimensions` which renders an empty div on the initial render.  Without the eager rendering the component pops in without animation on the first expand, but then animates correctly on subsequent expands.