### PR TITLE
Pass all uncaptured props to outer DOM element

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,6 @@ module.exports = {
     "space-before-blocks": ["error", "always"],
     "keyword-spacing": ["error"],
 
-    "no-unused-vars": ["error", {"args": "none"}]
+    "no-unused-vars": ["error", {"args": "none", "ignoreRestSiblings": true}]
   }
 };

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ takes the following props:
  be jarringly effected when the rule is added. You may want this prop turned on
  if the children contains a dropdown element which is meant to visually escape
  its container.
-* `className` allows a CSS class name to be added to the outer element. Care
- should be taken if any rules added by the class name conflict with
- SmoothCollapse's own CSS properties.
  * `eagerRender` will ensure that all children are always rendered, even if they
  have never been expanded. This property defaults to false.
+
+Additional props such as `className` will be passed on to the outer element. Care
+should be taken if any rules added by the class name conflict with
+SmoothCollapse's own CSS properties.
 
 If the SmoothCollapse component starts out with expanded set to false, eagerRender
 is set to false, and collapsedHeight is 0, then the children are not rendered until

--- a/src/index.js
+++ b/src/index.js
@@ -159,25 +159,28 @@ export default class SmoothCollapse extends React.Component<Props,State> {
 
   render() {
     const visibleWhenClosed = SmoothCollapse._visibleWhenClosed(this.props);
-    const {allowOverflowWhenOpen} = this.props;
+    const {
+      allowOverflowWhenOpen, children, collapsedHeight, eagerRender, expanded,
+      heightTransition, onChangeEnd, ...props
+    } = this.props;
     const {height, fullyClosed, renderInner} = this.state;
     const innerEl = renderInner ?
       <div ref={this._inner} style={{
         overflow: allowOverflowWhenOpen && height === 'auto' ? 'visible' : 'hidden'
       }}>
-        { this.props.children }
+        { children }
       </div>
       : null;
 
     return (
       <div
+        {...props}
         ref={this._main}
-        className={this.props.className}
         style={{
           height,
           overflow: allowOverflowWhenOpen && height === 'auto' ? 'visible' : 'hidden',
           display: (fullyClosed && !visibleWhenClosed) ? 'none': null,
-          transition: `height ${this.props.heightTransition}`
+          transition: `height ${heightTransition}`
         }}
       >
         {innerEl}


### PR DESCRIPTION
Fixes #22 by passing all uncaptured props to the outer `<div>`.