### PR TITLE
Add React 17 into peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": "^16.3.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
Hello!
Thank you for this project.

This PR adds React 17 into `peerDependencies`.
I have tested project in react@17.0.2. It works correctly.

Could you please merge it and publish new version with this fix?